### PR TITLE
Configure build base path for galerie deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/galeries/',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
## Summary
- set `base` to `/galeries/` in `vite.config.ts` for deployment under a subdirectory

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9fb53894832ba71f30a67e0c8ff4